### PR TITLE
Attach `client` instance to `on` and `once` helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,9 +96,9 @@ let command = function (dest, command) {
   });
 };
 
-let on = client.on;
+let on = client.on.bind(client);
 
-let once = client.once;
+let once = client.once.bind(client);
 
 module.exports = {
   command: command,


### PR DESCRIPTION
This allows attached event handlers to being triggered on `client.emit` calls.